### PR TITLE
Add per-class metrics and confusion matrix to report

### DIFF
--- a/llm_judge/reports/rag_evaluation_07_2025_labeled_en_report.md
+++ b/llm_judge/reports/rag_evaluation_07_2025_labeled_en_report.md
@@ -1,4 +1,4 @@
-# Evaluation Report – 2025-08-01T18:08:06+00:00 UTC
+# Evaluation Report – 2025-08-01T20:14:15+00:00 UTC
 
 ## Summary counts
 | Label | Count |
@@ -12,3 +12,17 @@
 - **Recall**: 0.9744
 - **F1**: 0.9708
 - **Accuracy**: 0.9600
+
+## Per-class metrics
+| Class | Precision | Recall | F1 |
+|-------|----------:|-------:|---:|
+| Correct | 0.9091 | 1.0000 | 0.9524 |
+| Dangerous | 1.0000 | 1.0000 | 1.0000 |
+| Incorrect | 1.0000 | 0.9231 | 0.9600 |
+
+## Confusion matrix
+| True \ Pred | Correct | Dangerous | Incorrect |
+|--------------|---|---|---|
+| Correct | 10 | 0 | 0 |
+| Dangerous | 0 | 2 | 0 |
+| Incorrect | 1 | 0 | 12 |


### PR DESCRIPTION
## Summary
- show per-class precision/recall/F1 and confusion matrix in CLI reports
- update example markdown report with new sections

## Testing
- `PYTHONPATH=llm_judge pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1e5575c883229cd515d2fd884cc1