### PR TITLE
Add root main entry point for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ using the `precision_recall_f1` function. The overall score reported is the
 
 ## Quick Start
 
+Run the evaluation from the repository root:
+
 ```bash
-cd llm_judge
-python -m src.cli --in data/rag_evaluation_07_2025.csv --model mistral-large-latest --temperature 0.0 --seed 0
+python main.py --csv llm_judge/data/rag_evaluation_07_2025.csv --model mistral-large-latest --temperature 0.0 --seed 0
 ```
 
 ## Usage
@@ -61,11 +62,11 @@ python -m src.cli --in data/rag_evaluation_07_2025.csv --model mistral-large-lat
 ### Command Line Interface
 
 ```bash
-python -m src.cli --in data/my.csv [--model mistral-large-latest] [--out out.csv] [--temperature 0.0] [--seed 0]
+python main.py --csv llm_judge/data/my.csv [--model mistral-large-latest] [--out out.csv] [--temperature 0.0] [--seed 0]
 ```
 
 **Arguments:**
-- `--in`: Input CSV file path (required)
+- `--csv`: Input CSV file path (required)
 - `--out`: Optional output CSV path (defaults to input_file.judged.csv)
 - `--model`: Mistral model name (default: mistral-large-latest)
 - `--temperature`: Sampling temperature (default: 0.0)
@@ -98,7 +99,7 @@ The system generates:
 Run tests with:
 ```bash
 cd llm_judge
-pytest tests/
+python -m pytest tests/
 ```
 
 ## Configuration

--- a/main.py
+++ b/main.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Repository entry point for LLM-as-a-Judge.
+
+This thin wrapper lets users run the command-line interface from the
+repository root using ``python main.py``.  It simply forwards arguments to
+``src.cli.main`` while supporting ``--csv`` as an alias for ``--in``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make the project package importable
+sys.path.insert(0, str(Path(__file__).parent / "llm_judge"))
+
+from src.cli import main as cli_main  # type: ignore
+
+
+def main() -> None:
+    """Entry point that normalizes CLI arguments and delegates to ``src.cli``."""
+    # Replace ``--csv`` with the ``src.cli`` expected ``--in`` flag
+    args = ["--in" if arg == "--csv" else arg for arg in sys.argv[1:]]
+    sys.argv = [sys.argv[0]] + args
+    cli_main()
+
+
+if __name__ == "__main__":  # pragma: no cover - thin wrapper
+    main()


### PR DESCRIPTION
## Summary
- document using `python main.py --csv` to run the judge from repository root
- expose CLI through new `main.py` wrapper that forwards `--csv` to `src.cli`

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d6e3d4cd8832290295ff29f97868e